### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,14 +2,11 @@
 <meta charset="utf-8"/>
 <title>AI Order – health & sync test</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<style>
-  body{font:14px system-ui, sans-serif;max-width:720px;margin:2rem auto;padding:0 1rem}
-  input{width:100%;max-width:560px}
-  pre{white-space:pre-wrap;background:#f6f8fa;border:1px solid #e1e4e8;border-radius:6px;padding:10px}
-  .row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
-  .muted{color:#6b7280;font-size:.85rem}
-</style>
+<link rel="stylesheet" href="styles.css"/>
 <h1>AI Order – Test connection</h1>
+<div class="row">
+  <button id="toggle-dark">Dark mode</button>
+</div>
 
 <p class="muted">
   1) U polje ispod nalepi <b>HTTPS forwarded</b> URL backend-a (Codespaces port 8080, Visibility: Public), npr.<br>
@@ -69,5 +66,9 @@
     const url = base + '/sync?withInventory=1&maxOrders=10&maxProducts=100&export=0';
     try { await doFetch(url, { method: 'POST' }); }
     catch(e){ $('out').textContent = 'ERROR: ' + (e && e.message || e); }
+  };
+
+  $('toggle-dark').onclick = ()=>{
+    document.body.classList.toggle('dark');
   };
 </script>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,10 @@
+body{font:14px system-ui,sans-serif;max-width:720px;margin:2rem auto;padding:0 1rem}
+input{width:100%;max-width:560px}
+pre{white-space:pre-wrap;background:#f6f8fa;border:1px solid #e1e4e8;border-radius:6px;padding:10px}
+.row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
+.muted{color:#6b7280;font-size:.85rem}
+
+/* Dark mode */
+body.dark{background:#111;color:#eee}
+body.dark pre{background:#1e1e1e;border-color:#374151}
+body.dark .muted{color:#9ca3af}


### PR DESCRIPTION
## Summary
- extract inline styles to docs/styles.css
- add dark mode styles and toggle button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba1d2d0f08833195eb104857029790