### PR TITLE
Add dark theme toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8"/>
 <title>AI Order – health & sync test</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="stylesheet" href="styles.css"/>
 <style>
   body{font:14px system-ui, sans-serif;max-width:720px;margin:2rem auto;padding:0 1rem}
   input{width:100%;max-width:560px}
@@ -23,6 +24,7 @@
   <input id="api" placeholder="https://<tvoj-8080-URL>" />
   <button id="health">Test /health</button>
   <button id="sync">Test /sync (mali)</button>
+  <button id="theme">🌓 Tema</button>
 </div>
 
 <p class="muted">Može i preko URL parametra: <code>?api=https://…</code> (auto-popunjava polje).</p>
@@ -69,5 +71,9 @@
     const url = base + '/sync?withInventory=1&maxOrders=10&maxProducts=100&export=0';
     try { await doFetch(url, { method: 'POST' }); }
     catch(e){ $('out').textContent = 'ERROR: ' + (e && e.message || e); }
+  };
+
+  $('theme').onclick = () => {
+    document.body.classList.toggle('dark');
   };
 </script>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,22 @@
+body.dark {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}
+
+body.dark pre {
+  background: #374151;
+  border-color: #4b5563;
+}
+
+body.dark input {
+  background: #1f2937;
+  color: #f3f4f6;
+  border: 1px solid #4b5563;
+}
+
+body.dark button {
+  background: #4b5563;
+  color: #f9fafb;
+  border: none;
+}
+


### PR DESCRIPTION
## Summary
- add "🌓 Tema" button to toggle dark mode
- include dark theme styles and stylesheet link

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba1d5e73308331ac6750110e57907e